### PR TITLE
Added column for the source of the data to the Product Browser page

### DIFF
--- a/src/pages/tools/Product_browser/index.jsx
+++ b/src/pages/tools/Product_browser/index.jsx
@@ -61,6 +61,13 @@ const Product_browser = () => {
         minWidth: 230,
         flex: 2,
         renderCell: (params) => <a href={`${params.row.siteUrl}`}>{params.row.storeEntity.name}</a>
+    },
+    { 
+      field: 'source',
+      headerName: "Web Scrape",
+      minWidth: 150,
+      flex: 2,
+      renderCell: (params) => params.row.sourceEntity.name
     }
   ];
 


### PR DESCRIPTION
- For now, its an empty column, but once the API side is done, the column will tell whether the data comes from FLIP or Scrape